### PR TITLE
Don't set isident because it's global variable

### DIFF
--- a/syntax/gas.vim
+++ b/syntax/gas.vim
@@ -14,7 +14,6 @@ elseif exists("b:current_syntax")
 endif
 
 setlocal iskeyword +=%,.,-,_
-setlocal isident   +=%,.,-,_
 
 syn case ignore
 


### PR DESCRIPTION
From `:help isident`:
```
						*'isident'* *'isi'*
'isident' 'isi'		string	(default for MS-DOS, Win32 and OS/2:
					   "@,48-57,_,128-167,224-235"
				otherwise: "@,48-57,_,192-255")
			global
	The characters given by this option are included in identifiers.
	Identifiers are used in recognizing environment variables and after a
	match of the 'define' option.  It is also used for "\i" in a
	|pattern|.  See 'isfname' for a description of the format of this
	option.  For '@' only characters up to 255 are used.
	Careful: If you change this option, it might break expanding
	environment variables.  E.g., when '/' is included and Vim tries to
	expand "$HOME/.viminfo".  Maybe you should change 'iskeyword' instead.
```

This plugin doesn't use `\i` in patterns, so it's okay to safely remove the line.

The script uses `setlocal isident`, but actually, it's `set isident` as `isident` is a global option. After setting `isident`, following command will cause an `E15: Invalid expression` error:
``` vim
let test = $SOME_VARIABLE.' '
```